### PR TITLE
优化分页组件请求两次问题的实现方式

### DIFF
--- a/src/components/Pagination/index.vue
+++ b/src/components/Pagination/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div :class="{ 'hidden': hidden }" class="pagination-container">
     <el-pagination
-      v-if="pageShow"
       :background="background"
       v-model:current-page="currentPage"
       v-model:page-size="pageSize"
@@ -18,7 +17,6 @@
 <script setup>
 import { scrollTo } from '@/utils/scroll-to'
 
-const pageShow = ref(true);
 
 const props = defineProps({
   total: {
@@ -81,10 +79,7 @@ const pageSize = computed({
 })
 function handleSizeChange(val) {
   if (currentPage.value * val > props.total) {
-    pageShow.value = false;
-    nextTick(() => {
-      pageShow.value = true
-    })
+    currentPage.value = 1
   }
   emit('pagination', { page: currentPage.value, limit: val })
   if (props.autoScroll) {


### PR DESCRIPTION
按照原先的修复逻辑来执行代码（也就是让分页组件重新渲染），会出现当前页数失效的情况，即分页组件无法识别当前页数。