### PR TITLE
修复用户管理页面,左侧部门数据的部门搜索框icon错误使用vue2版本的element-ui的问题

### DIFF
--- a/src/views/system/user/index.vue
+++ b/src/views/system/user/index.vue
@@ -8,7 +8,7 @@
                   v-model="deptName"
                   placeholder="请输入部门名称"
                   clearable
-                  prefix-icon="el-icon-search"
+                  prefix-icon="Search"
                   style="margin-bottom: 20px"
                />
             </div>


### PR DESCRIPTION
用户管理界面，部门名称搜索框，使用了vue2版本的element-ui的icon名，导致无法渲染正确的搜索图标